### PR TITLE
add workflow_call to build-api

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -1,6 +1,7 @@
 name: api build
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
re-adds workflow_call into github workflow for build-api. It got accidentally removed when I copied over fulcrum's configuration.